### PR TITLE
Add ability to get motor telemetry data

### DIFF
--- a/yamspy/__init__.py
+++ b/yamspy/__init__.py
@@ -145,6 +145,15 @@ class MSPy:
 
         self.MOTOR_DATA = [0]*8
 
+        self.MOTOR_TELEMETRY_DATA = {
+            'rpm': [0]*8,
+            'invalidPercent': [0]*8,
+            'temperature': [0]*8,
+            'voltage': [0]*8,
+            'current': [0]*8,
+            'consumption': [0]*8,
+        }
+
         # defaults
         # roll, pitch, yaw, throttle, aux 1, ... aux n
         self.RC = {
@@ -1072,6 +1081,16 @@ class MSPy:
     def process_MSP_MOTOR(self, data):
         motorCount = int(len(data) / 2)
         self.MOTOR_DATA = [self.readbytes(data, size=16, unsigned=True) for i in range(motorCount)]
+
+    def process_MSP_MOTOR_TELEMETRY(self, data):
+        motorCount = self.readbytes(data, size=8, unsigned=True)
+        for i in range(motorCount):
+            self.MOTOR_TELEMETRY_DATA['rpm'][i] = self.readbytes(data, size=32, unsigned=True)
+            self.MOTOR_TELEMETRY_DATA['invalidPercent'][i] = self.readbytes(data, size=16, unsigned=True)
+            self.MOTOR_TELEMETRY_DATA['temperature'][i] = self.readbytes(data, size=8, unsigned=True)
+            self.MOTOR_TELEMETRY_DATA['voltage'][i] = self.readbytes(data, size=16, unsigned=True)
+            self.MOTOR_TELEMETRY_DATA['current'][i] = self.readbytes(data, size=16, unsigned=True)
+            self.MOTOR_TELEMETRY_DATA['consumption'][i] = self.readbytes(data, size=16, unsigned=True)
 
     def process_MSP_RC(self, data):
         n_channels = int(len(data) / 2)


### PR DESCRIPTION
This PR adds the ability to process data received after sending the `MSP_MOTOR_TELEMETRY` MSP code. 

This implementation is based off of betaflight configurator's implementation: https://github.com/betaflight/betaflight-configurator/blob/dd16cb767989ecfefe76d6779969466a53d5bd63/src/js/msp/MSPHelper.js#L273

**Example usage**:
```python
from yamspy import MSPy
from yamspy.msp_codes import MSPCodes

board = MSPy(device=<serial-port>)
board.connect()

# Set the four motors to 1500 throttle
board.send_RAW_MOTORS([1500, 1500, 1500, 1500, 0, 0, 0, 0])

# Read back the motor telemetry
board.send_RAW_msg(MSPCodes['MSP_MOTOR_TELEMETRY'])
dataHandler = board.receive_msg()
board.process_recv_data(dataHandler)

# Print out the telemetry values
print(board.MOTOR_TELEMETRY_DATA)
```

This was tested on a Happymodel Crux 3 running betaflight.