### PR TITLE
Add ability to get motor telemetry data from FC/ESC

### DIFF
--- a/yamspy/__init__.py
+++ b/yamspy/__init__.py
@@ -145,6 +145,15 @@ class MSPy:
 
         self.MOTOR_DATA = [0]*8
 
+        self.MOTOR_TELEMETRY_DATA = {
+            'rpm': [0]*8,
+            'invalidPercent': [0]*8,
+            'temperature': [0]*8,
+            'voltage': [0]*8,
+            'current': [0]*8,
+            'consumption': [0]*8,
+        }
+
         # defaults
         # roll, pitch, yaw, throttle, aux 1, ... aux n
         self.RC = {
@@ -2035,6 +2044,16 @@ class MSPy:
             pass # API no longer supported (INAV 2.3.0)
     def process_MSP_SET_BLACKBOX_CONFIG(self, data):
         logging.info("Blackbox config saved")
+
+    def process_MSP_MOTOR_TELEMETRY(self, data):
+        motorCount = self.readbytes(data, size=8, unsigned=True)
+        for i in range(motorCount):
+            self.MOTOR_TELEMETRY_DATA['rpm'][i] = self.readbytes(data, size=32, unsigned=True)
+            self.MOTOR_TELEMETRY_DATA['invalidPercent'][i] = self.readbytes(data, size=16, unsigned=True)
+            self.MOTOR_TELEMETRY_DATA['temperature'][i] = self.readbytes(data, size=8, unsigned=True)
+            self.MOTOR_TELEMETRY_DATA['voltage'][i] = self.readbytes(data, size=16, unsigned=True)
+            self.MOTOR_TELEMETRY_DATA['current'][i] = self.readbytes(data, size=16, unsigned=True)
+            self.MOTOR_TELEMETRY_DATA['consumption'][i] = self.readbytes(data, size=16, unsigned=True)  
 
     # TODO: This changed and it will need to check the BF version to decode things correctly
     # def process_MSP_TRANSPONDER_CONFIG(self, data):


### PR DESCRIPTION
This PR is the same as #27, but based on the `yp/stable` branch instead of `yp/dev`.

I don't have any preference if only one or both of the PRs get merged. Whatever the maintainers think is fine with me.